### PR TITLE
fix: Prevent cameras from locking up after the main application crashes

### DIFF
--- a/amiga-app/backend/cameraBackend/oakManager.py
+++ b/amiga-app/backend/cameraBackend/oakManager.py
@@ -84,6 +84,8 @@ def startCameras(queue: Queue, POINTCLOUD_DATA_DIR: str) -> None:
         # positioning. Calibration requires calibration pattern and is
         # mandatory. Alignment is optional and can be done on the fly.
         while True:
+            if os.getppid() == 1:     # 1 means parent is gone
+                sys.exit(1)
             try:
                 msg = queue.get(timeout=0.1)  # Blocking
                 action = msg.get("action", "No action")

--- a/amiga-app/backend/cameraBackend/oakManager.py
+++ b/amiga-app/backend/cameraBackend/oakManager.py
@@ -84,7 +84,7 @@ def startCameras(queue: Queue, POINTCLOUD_DATA_DIR: str) -> None:
         # positioning. Calibration requires calibration pattern and is
         # mandatory. Alignment is optional and can be done on the fly.
         while True:
-            if os.getppid() == 1:     # 1 means parent is gone
+            if os.getppid() == 1:  # 1 means parent is gone
                 sys.exit(1)
             try:
                 msg = queue.get(timeout=0.1)  # Blocking

--- a/amiga-app/backend/main.py
+++ b/amiga-app/backend/main.py
@@ -93,7 +93,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[dict, None]:
             oak_manager = None
         else:
             oak_manager = Process(
-                target=startCameras, args=(camera_msg_queue, config.POINTCLOUD_DATA_DIR)
+                target=startCameras, args=(camera_msg_queue, config.POINTCLOUD_DATA_DIR), daemon=True
             )
             oak_manager.start()
             print(f"Starting oak manager with PID {oak_manager.pid}")

--- a/amiga-app/backend/main.py
+++ b/amiga-app/backend/main.py
@@ -93,7 +93,9 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[dict, None]:
             oak_manager = None
         else:
             oak_manager = Process(
-                target=startCameras, args=(camera_msg_queue, config.POINTCLOUD_DATA_DIR), daemon=True
+                target=startCameras,
+                args=(camera_msg_queue, config.POINTCLOUD_DATA_DIR),
+                daemon=True,
             )
             oak_manager.start()
             print(f"Starting oak manager with PID {oak_manager.pid}")


### PR DESCRIPTION
Added check to the child camera manager process to ensure it will terminate after it detects the main application has ended.